### PR TITLE
This fixes some cases where bazel hangs forever.

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -6,6 +6,7 @@
   "allowOffline": true,
   "errorsBeforePausing": 3,
   "pauseMinutes": 5,
+  "socketTimeoutSeconds": 600, // Default is 120 seconds
   "maxEntrySizeBytes": 64000000, // max size for one item uploaded to S3; 0 means no limit
 
   "asyncUpload": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export interface Config {
     allowOffline?: boolean;
     errorsBeforePausing?: number;
     pauseMinutes?: number;
+    socketTimeoutSeconds?: number;
     maxEntrySizeBytes?: number;
 
     asyncUpload?: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -176,6 +176,13 @@ export function startServer(s3: AWS.S3, config: Config, onDoneInitializing: () =
     clearAsyncUploadCache();
 
     const server = http.createServer((req: http.ServerRequest, res: http.ServerResponse) => {
+        res.setTimeout(config.socketTimeoutSeconds * 1000, () => {
+            // Oh well, we can't wait forever bail out on this request and close the socket
+            winston.warn("Socket timeout reached. Returning NotFound");
+            res.statusCode = StatusCode.NotFound;
+            sendResponse(req, res, null, {startTime, awsPaused });
+        });
+
         if (idleTimer) {
             clearTimeout(idleTimer);
         }


### PR DESCRIPTION
If the connection/socket bazel has opened with the remote cache
closes unexpectedly (without a response) then the bazel build
would hang forever. I replicated the effects we had observed here
[[Private Link]](https://app.asana.com/0/41418719780575/639438010491097/f)
by setting a very small socket timeout. I fixed it on the bazels3cache
side by returning a 404 when the socket times out (instead of just closing
the socket) and made the socket timeout configurable and set it to
10 minutes instead of the (2-minute default).

This allows us to tune the behavior of the cache for slow connections.
With a small socket timeout (quicker bailout) slow connections will
wait just a small amount of time for the cache before starting to build
it them-selves, while fast connections will still be able to fetch most of
the files.  So maybe the default should be less than 10 minutes but we 
can address that later.

