### PR TITLE
Decrease socket timeout from 10 mins to 30 seconds

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -6,7 +6,7 @@
   "allowOffline": true,
   "errorsBeforePausing": 3,
   "pauseMinutes": 5,
-  "socketTimeoutSeconds": 600, // Default is 120 seconds
+  "socketTimeoutSeconds": 30, // Default is 120 seconds
   "maxEntrySizeBytes": 64000000, // max size for one item uploaded to S3; 0 means no limit
 
   "asyncUpload": {


### PR DESCRIPTION
If for some reason we need more than 30 seconds to respond then we should bail out and let the consumer of the cache do whatever they need to do.