### PR TITLE
Disable the in memory cache by default

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -16,7 +16,7 @@
   },
 
   "cache": { // settings related to the in-memory cache
-    "enabled": true,
+    "enabled": false,
     "maxEntrySizeBytes": 1000000, // max size for items retained in memory
     "maxTotalSizeBytes": 50000000 // be careful, this is an in-memory cache
   },


### PR DESCRIPTION
While the in memory cache can potentially decrease the number of server
requests which need to be made, we think that for most use cases it is
better and more reliable to run with it disabled.