### PR TITLE
Add --host option

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,5 +1,6 @@
 // comments are allowed in this json file
 {
+  "host": "localhost",
   "port": 7777,
   "bucket": null, // specify this on command line or in another config file
   "idleMinutes": 0, // 0 means live forever; >0 means exit automatically after idle time

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export interface Args {
 // config file (e.g. --config=myconfig.json), and any command-line arguments
 // (e.g. --cache.maxEntrySizeBytes=1234)
 export interface Config {
+    host?: string;
     port?: number;
     idleMinutes?: number;
     bucket?: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,8 +19,6 @@ enum StatusCode {
     MethodNotAllowed = 405,
 };
 
-const hostname = "localhost";
-
 function logProps(
     req: http.ServerRequest,
     res: http.ServerResponse,
@@ -394,11 +392,11 @@ export function startServer(s3: AWS.S3, config: Config, onDoneInitializing: () =
         process.exitCode = 1;
     });
 
-    server.listen(config.port, hostname, () => {
+    server.listen(config.port, config.host, () => {
         const logfile = path.resolve(config.logging.file);
-        debug(`started server at http://${hostname}:${config.port}/`);
-        winston.info(`started server at http://${hostname}:${config.port}/`);
-        console.log(`bazels3cache: started server at http://${hostname}:${config.port}/, logging to ${logfile}`);
+        debug(`started server at http://${config.host}:${config.port}/`);
+        winston.info(`started server at http://${config.host}:${config.port}/`);
+        console.log(`bazels3cache: started server at http://${config.host}:${config.port}/, logging to ${logfile}`);
         onDoneInitializing();
     });
 }


### PR DESCRIPTION
bazels3cache can be invoked with `--host` to specify a host other than`localhost` on which bazels3cache will listen for incomimg requests. For example, in some scenarios you might want to use 0.0.0.0.

Addresses https://github.com/Asana/bazels3cache/issues/18