### PR TITLE
Check asyncUpload.maxPendingUploadMB only if enabled

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -277,7 +277,7 @@ export function startServer(s3: AWS.S3, config: Config, onDoneInitializing: () =
                             res.statusCode = StatusCode.OK; // tell Bazel the PUT succeeded
                             sendResponse(req, res, size, { startTime, awsPaused });
                             safeUnlinkSync(pth);
-                        } else if (pendingUploadBytes + size > config.asyncUpload.maxPendingUploadMB * 1024 * 1024) {
+                        } else if (config.asyncUpload.enabled && pendingUploadBytes + size > config.asyncUpload.maxPendingUploadMB * 1024 * 1024) {
                             winston.info(`Not uploading ${s3key}, because there are already too many pending uploads`);
                             res.statusCode = StatusCode.OK; // tell Bazel the PUT succeeded
                             sendResponse(req, res, size, { startTime, awsPaused });


### PR DESCRIPTION
At the moment, if you run the server with `asyncUpload.enabled=false`, you can still get a transfer interrupted due to "too many pending uploads".

This can happen, if the size of the file to upload happens to be larger than the value of `asyncUpload.maxPendingUploadMB`